### PR TITLE
BUATrackEventsGTM ignores events without additional data fix

### DIFF
--- a/BlazorUniversalAnalytics/wwwroot/blazor.universal.analytics.js
+++ b/BlazorUniversalAnalytics/wwwroot/blazor.universal.analytics.js
@@ -99,9 +99,13 @@ export function BUATrackEventsFacebookPixel(eventName, objectValue) {
 }
 
 export function BUATrackEventsGTM(eventName, objectValue) {
-    if (eventName !== null && objectValue !== null) {
+    if (typeof objectValue === "object" && objectValue !== null) {
         objectValue['event'] = eventName;
         dataLayer.push(objectValue);
+    }
+    else
+    {
+        dataLayer.push({'event': eventName});
     }
 }
 


### PR DESCRIPTION
The JS function which pushes data to GTM dataLayer, has this condition if you don't pass any data it simply ignores the function call.

https://github.com/welisonmenezes/blazor-universal-analytics/blob/1b13b0c976206da84e93703fb0c25f6d49f05100/BlazorUniversalAnalytics/wwwroot/blazor.universal.analytics.js#L102

I am suggesting to make objectValue prameter optional, like in BUATrackEventsFacebookPixel.

According [GTAG documentation](https://developers.google.com/tag-platform/tag-manager/web/datalayer#use_a_data_layer_with_event_handlers), only eventName can be pushed.